### PR TITLE
Optional values should set a default of null

### DIFF
--- a/src/main/scala/com/gu/marley/AvroSchema.scala
+++ b/src/main/scala/com/gu/marley/AvroSchema.scala
@@ -37,6 +37,7 @@ case class AvroMapSchema(valueSchema: AvroSchema) extends AvroSchema {
 
 case class AvroRecordSchema(name: String, namespace: String, fields: (String, AvroSchema)*) extends AvroSchema {
   def apply() = fields.foldLeft(SchemaBuilder.record(name).namespace(namespace).fields) {
+    case (b, (k, v: AvroOptionSchema)) => b.name(k).`type`(v()).withDefault(null)
     case (b, (k, v)) => b.name(k).`type`(v()).noDefault
   }.endRecord
 }


### PR DESCRIPTION
In order for [schema evolution](http://docs.oracle.com/cd/E26161_02/html/GettingStartedGuide/schemaevolution.html) to work correctly, new optional fields should be marked with a default value of null.