### PR TITLE
Fix union schemas to have a consistent and reproducible order

### DIFF
--- a/core/src/main/scala/com/gu/marley/AvroSerialisable.scala
+++ b/core/src/main/scala/com/gu/marley/AvroSerialisable.scala
@@ -203,9 +203,12 @@ class AvroSerialisableMacro(val c: blackbox.Context) {
   }
 
   def unionMacro[T: c.WeakTypeTag]: Tree = {
+    implicit val symbolOrdering: Ordering[c.universe.Symbol] = Ordering.by(_.fullName)
+
     val typ = weakTypeOf[T].dealias
     if (typ.typeSymbol.isAbstract) {
-      val subClasses = typ.typeSymbol.asClass.knownDirectSubclasses
+      val subClasses: Seq[c.universe.Symbol] = // we need reproducible ordering for schema fingerprinting!
+        typ.typeSymbol.asClass.knownDirectSubclasses.toSeq.sorted
 
       val cases = subClasses map { cl =>
         val typ = tq"${cl.asType}"


### PR DESCRIPTION
We want the schemas coming from the `AvroSerialisable`'s generated by Marley to be consistent and reproducible - this allows us to use fingerprinting of the schema to track compatibility of the schema with previous versions, like in Ophan's [`AvroSchemaCompatibilityTest`](https://github.com/guardian/ophan/blob/3dbb3dc3/avro-logger/src/test/scala/lib/AvroSchemaCompatibilityTest.scala#L32).

Support for Avro `union` types was added to Marley with #3 in aeec5f3e01, allowing code like this:

```
val atomData = union[AtomData] // Sub-types of the AtomData trait include Guide, Quiz, etc
```

...but unfortunately the order of the sub-types (`com.gu.contentatom.thrift.AtomData.Quiz`, `com.gu.contentatom.thrift.AtomData.Guide`, etc) listed in the union schema generated by Marley was dependent on the ordering of `knownDirectSubclasses`:

https://github.com/guardian/marley/blob/aeec5f3e016d99e4d7987d88b1178982d01ed552/src/main/scala/com/gu/marley/AvroSerialisable.scala#L208
...`knownDirectSubclasses` is of type `Set[Universe.Symbol]`, and it was iterated over to make the `schema`:
https://github.com/guardian/marley/blob/aeec5f3e016d99e4d7987d88b1178982d01ed552/src/main/scala/com/gu/marley/AvroSerialisable.scala#L230-L237

...because it was a `Set`, it did not have a predictable iteration order. I think this bug is probably what led to the intermittent build failures reported in https://github.com/guardian/ophan/pull/2551#discussion_r152560122 - as a test, I ran a version of that branch with the old Marley (several failures, some passes):

![image](https://user-images.githubusercontent.com/52038/35729494-c5e18f9e-0806-11e8-9d71-89e079e442ca.png)

...and then the same branch, but with a [test build of the new Marley](https://github.com/guardian/ophan/commit/1df86587277) (consistently passed):

![image](https://user-images.githubusercontent.com/52038/35729555-0436c41c-0807-11e8-81d7-3da6ddf7995e.png)
