### PR TITLE
Fix Travis-CI build, bump dependency versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: scala
 scala:
+- 2.12.10
 - 2.11.12
 jdk:
-- oraclejdk8
+- openjdk8
+- openjdk11
 sudo: false
 cache:
   directories:

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion in ThisBuild := "2.12.4"
+scalaVersion in ThisBuild := "2.12.10"
 
 crossScalaVersions in ThisBuild := Seq(scalaVersion.value, "2.11.12")
 
@@ -8,8 +8,8 @@ val commonSettings = Seq(
   licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
   libraryDependencies ++= Seq(
     "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-    "com.twitter" %% "scrooge-core" % "4.12.0",
-    "org.apache.thrift" % "libthrift" % "0.9.2"
+    "com.twitter" %% "scrooge-core" % "19.10.0",
+    "org.apache.thrift" % "libthrift" % "0.12.0"
   )
 )
 
@@ -17,11 +17,11 @@ lazy val core = project.settings(
   name := "marley",
   libraryDependencies ++= Seq(
     "org.apache.avro" % "avro" % "1.7.7",
-    "org.parboiled" %% "parboiled" % "2.1.4",
+    "org.parboiled" %% "parboiled" % "2.1.8",
     "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided",
     compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full),
-    "org.scalatest" %% "scalatest" % "3.0.5" % Test,
-    "org.scalacheck" %% "scalacheck" % "1.13.5" % Test
+    "org.scalatest" %% "scalatest" % "3.0.8" % Test,
+    "org.scalacheck" %% "scalacheck" % "1.14.2" % Test
   )
 ).settings(commonSettings: _*).dependsOn(thriftExample % "test->test")
 
@@ -36,10 +36,13 @@ lazy val root = (project in file(".")).aggregate(core).settings(
   publishLocal := {}
 )
 
+publishTo := sonatypePublishToBundle.value
+
 import ReleaseTransformations._
+import sbt.Keys.scalaBinaryVersion
 
 releaseCrossBuild := true // true if you cross-build the project for multiple Scala versions
-releasePublishArtifactsAction := PgpKeys.publishSigned.value
+
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,
@@ -48,9 +51,11 @@ releaseProcess := Seq[ReleaseStep](
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease,
+  // For non cross-build projects, use releaseStepCommand("publishSigned")
   releaseStepCommandAndRemaining("+publishSigned"),
+  releaseStepCommand("sonatypeBundleRelease"),
   setNextVersion,
   commitNextVersion,
-  releaseStepCommand("sonatypeReleaseAll"),
   pushChanges
 )
+

--- a/core/src/main/scala/com/gu/marley/AvroSerialisable.scala
+++ b/core/src/main/scala/com/gu/marley/AvroSerialisable.scala
@@ -6,7 +6,6 @@ import org.apache.avro.Schema.Type
 import collection.convert.decorateAll._
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
-import macrocompat.bundle
 
 
 trait AvroSerialisable[T] {
@@ -102,7 +101,7 @@ object AvroSerialisable extends LowPriorityImplicitSerialisable {
 trait LowPriorityImplicitSerialisable {
   implicit def struct[T <: ThriftStruct]: AvroSerialisable[T] = macro AvroSerialisableMacro.structMacro[T]
 }
-@bundle
+
 class AvroSerialisableMacro(val c: blackbox.Context) {
   import c.universe._
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.3.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,11 @@
 // Scrooge relies on an ancient version of thrift that's not on maven central
 // Instead, force a slightly more recent version
-libraryDependencies += "org.apache.thrift" % "libthrift" % "0.6.1"
+libraryDependencies += "org.apache.thrift" % "libthrift" % "0.12.0"
 
-addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "4.12.0")
+addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "19.10.0")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.7")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.1")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8")
+
+


### PR DESCRIPTION
* Fix Travis-CI  to use OpenJDK rather than the now unavailable oraclejdk8 (and compile against both openjdk8 & openjdk11, because one day...)
* Modernise all the dependencies
* Drop use of `macrocompat.bundle` annotation, which was only needed for Scala v2.10 - from https://github.com/milessabin/macro-compat#why-you-should-use-macro-compat:

> The `@bundle` annotation is implemented as a macro annotation via the macro-paradise compiler plugin (the plugin is no longer necessary with 2.13.x). On Scala 2.11.x, 2.12.x and 2.13.x the annotation is simply eliminated during compilation, leaving no trace in the resulting binaries. On Scala 2.10.x the annotation macro transforms the macro bundle class to an object definition which is compatible with the 2.10.x macro API.