### PR TITLE
Add Scala v2.13 support, drop Scala v2.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 scala:
+- 2.13.1
 - 2.12.10
-- 2.11.12
 jdk:
 - openjdk8
 - openjdk11

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
-scalaVersion in ThisBuild := "2.12.10"
+scalaVersion in ThisBuild := "2.13.1"
 
-crossScalaVersions in ThisBuild := Seq(scalaVersion.value, "2.11.12")
+crossScalaVersions in ThisBuild := Seq(scalaVersion.value, "2.12.10")
 
 val commonSettings = Seq(
   organization := "com.gu",
@@ -13,13 +13,19 @@ val commonSettings = Seq(
   )
 )
 
+def versionDependent[T](scalaV: String, handlesAnnotations: Boolean, value: T):Option[T] = {
+  val preMacroAnnotationsScalaVersions = Set("2.11", "2.12")
+  Some(value).filter(_ => handlesAnnotations != preMacroAnnotationsScalaVersions.contains(scalaV))
+}
+
 lazy val core = project.settings(
   name := "marley",
-  libraryDependencies ++= Seq(
+  Compile / scalacOptions += versionDependent(scalaBinaryVersion.value, handlesAnnotations=true, "-Ymacro-annotations"),
+  libraryDependencies ++= versionDependent(scalaBinaryVersion.value, handlesAnnotations=false,
+    compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full)).toSeq ++ Seq(
     "org.apache.avro" % "avro" % "1.7.7",
     "org.parboiled" %% "parboiled" % "2.1.8",
     "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided",
-    compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full),
     "org.scalatest" %% "scalatest" % "3.0.8" % Test,
     "org.scalacheck" %% "scalacheck" % "1.14.2" % Test
   )

--- a/core/src/main/scala/com/gu/marley/AvroFile.scala
+++ b/core/src/main/scala/com/gu/marley/AvroFile.scala
@@ -40,7 +40,7 @@ object AvroFile {
     val datumReader = new GenericDatumReader[GenericRecord]()
     val dataFileReader = new DataFileReader[GenericRecord](file, datumReader)
 
-    import collection.convert.wrapAsScala._
+    import collection.JavaConverters._
 
     try {
       iterableAsScalaIterable(dataFileReader).map(AvroSerialisable.read[T])

--- a/core/src/main/scala/com/gu/marley/AvroSchema.scala
+++ b/core/src/main/scala/com/gu/marley/AvroSchema.scala
@@ -4,7 +4,7 @@ import com.twitter.scrooge.ThriftEnum
 import org.apache.avro.Schema.Type
 import org.apache.avro.{SchemaBuilder, Schema}
 
-import collection.convert.decorateAsJava._
+import collection.JavaConverters._
 
 trait AvroSchema {
   def apply(): Schema

--- a/core/src/main/scala/com/gu/marley/AvroSerialisable.scala
+++ b/core/src/main/scala/com/gu/marley/AvroSerialisable.scala
@@ -3,7 +3,7 @@ import com.twitter.scrooge.{ThriftEnum, ThriftStruct, ThriftUnion}
 import org.apache.avro.Schema
 import org.apache.avro.Schema.Type
 
-import collection.convert.decorateAll._
+import collection.JavaConverters._
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
 
@@ -68,10 +68,10 @@ object AvroSerialisable extends LowPriorityImplicitSerialisable {
     override def read(x: Any): Option[T] = Option(x).map(w.read)
   }
 
-  def SeqAvroSerialisable[T](w: AvroSerialisable[T]) = new AvroSerialisable[Seq[T]] {
+  def SeqAvroSerialisable[T](w: AvroSerialisable[T]) = new AvroSerialisable[collection.Seq[T]] {
     override val schema = AvroSeqSchema(w.schema)
-    override def writableValue(t: Seq[T]): Any = t.map(w.writableValue).asJava
-    override def read(x: Any): Seq[T] = x.asInstanceOf[java.util.List[Any]].asScala.map(w.read).toSeq
+    override def writableValue(t: collection.Seq[T]): Any = t.map(w.writableValue).asJava
+    override def read(x: Any): collection.Seq[T] = x.asInstanceOf[java.util.List[Any]].asScala.map(w.read).toSeq
   }
 
   def SetAvroSerialisable[T](w: AvroSerialisable[T]) = new AvroSerialisable[scala.collection.Set[T]] {
@@ -275,7 +275,7 @@ class AvroSerialisableMacro(val c: blackbox.Context) {
     target.typeConstructor <:< reference.typeConstructor
 
   private val optionType = typeOf[Option[_]]
-  private val seqType = typeOf[Seq[_]]
+  private val seqType = typeOf[collection.Seq[_]]
   private val setType = typeOf[collection.Set[_]]
   private val mapType = typeOf[collection.Map[_, _]]
 

--- a/core/src/test/scala/com/gu/marley/AvroFileSpec.scala
+++ b/core/src/test/scala/com/gu/marley/AvroFileSpec.scala
@@ -25,7 +25,7 @@ class AvroFileSpec extends FlatSpec with Checkers {
       enum <- arbEnum
       bool <- arbitrary[Boolean]
       double <- arbitrary[Double]
-      seq <- arbitrary[Option[Seq[String]]]
+      seq <- arbitrary[Option[collection.Seq[String]]]
       substruct <- arbSubStruct
       set <- arbitrary[Option[Set[String]]]
       int <- arbitrary[Option[Int]]

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.2
+sbt.version=1.3.3


### PR DESCRIPTION
We're doing this library update as part of updating Ophan to Scala 2.13 (see https://github.com/guardian/ophan/issues/3462)

For those interested, here's a description of the issues addressed as we updated Marley (for people who have to debug Scala macro libraries, the 'how-did-I-debug-this?' section may be useful):

### Dealing with scala.Seq becoming scala.collection.immutable.Seq

From https://docs.scala-lang.org/overviews/core/collections-migration-213.html#scalaseq-varargs-and-scalaindexedseq-migration

> `scala.Seq[+A]` is now an alias for `scala.collection.immutable.Seq[A]`
> (instead of `scala.collection.Seq[A]`)

This change occurred with commit 457dfd074 in https://github.com/scala/scala/pull/6498 - it led to difficult-to-comprehend compilation errors for Marley with Scala 2.13:

```
[info] Compiling 1 Scala source to /home/roberto/guardian/marley/core/target/scala-2.13/test-classes ...
[error] /home/roberto/guardian/marley/core/src/test/scala/com/gu/marley/AvroFileSpec.scala:47:55: Expected the companion object of scala.collection.Seq[String] to have an 'apply' method
[error]       implicit val structSer = AvroSerialisable.struct[ExampleStruct]
[error]                                                       ^
[error] /home/roberto/guardian/marley/core/src/test/scala/com/gu/marley/AvroFileSpec.scala:54:35: Expected the companion object of scala.collection.Seq[String] to have an 'apply' method
[error]       AvroFile.read[ExampleStruct](file).head == struct
[error]                                   ^
[error] two errors found
[error] (core / Test / compileIncremental) Compilation failed
```

The error is saying _"Expected the companion object of `scala.collection.Seq[String]` to have an 'apply' method"_ because the `implicitFor()` method wasn't able to match `scala.collection.Seq[String]` using the `subTypeOf(typ, seqType)` on line 287:

https://github.com/guardian/marley/blob/849eae4d49895b169e53a9eb2ec7f565c544461c/core/src/main/scala/com/gu/marley/AvroSerialisable.scala#L278-L288

As `scala.collection.Seq[String]` *isn't* a subtype of `scala.collection.immutable.Seq[String]` (it's a supertype) there's no match found, and things-go-wrong.

Given a `list<string>` thrift field, Scrooge v19.2.0 and above (see [this](https://github.com/twitter/scrooge/blob/2324adba195e43232e406fe83ec6598a0d09d43c/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/ScalaGenerator.scala#L222-L224) & [that](https://contributors.scala-lang.org/t/experience-of-migrating-to-2-13-x/3367)) generate a Scala field of type `scala.collection.Seq[String]`, so we _have_ to ensure that our `implicitFor()` method can match against that precise type. Essentially the scrooge plugin, and we, in this change, are adopting "Option 1: migrate back to scala.collection.Seq" from the [Scala 2.13 migration guide](https://docs.scala-lang.org/overviews/core/collections-migration-213.html#option-1-migrate-back-to-scalacollectionseq).

See also:

https://www.scala-lang.org/blog/2017/02/28/collections-rework.html#language-integration
http://eed3si9n.com/masking-scala-seq

#### How did I debug this issue?

I've never written any Scala macros, so how did I debug this issue? Basically tonnes of printlns in the `AvroSerialisable` code, comparing the output when running Scala 2.12 vs 2.13. That showed me there was a divergence, but it was too noisy to really spot the problem. All I could really see was that `optListString: _root_.scala.Option[_root_.scala.collection.Seq[String]]`
was the field that was the problem.

Eventually I attached a debugger (see https://stackoverflow.com/a/15505308/438886) and set a breakpoint in the code on the line reporting the error:

https://github.com/guardian/marley/blob/849eae4d49895b169e53a9eb2ec7f565c544461c/core/src/main/scala/com/gu/marley/AvroSerialisable.scala#L270

...once the breakpoint was hit (it was only hit in Scala 2.13, not Scala 2.12), I looked back up the stacktrace, and set another breakpoint further up the code here:

https://github.com/guardian/marley/blob/849eae4d49895b169e53a9eb2ec7f565c544461c/core/src/main/scala/com/gu/marley/AvroSerialisable.scala#L161

...but this time with a breakpoint **condition** so it only suspended for the particular field that was causing a problem:

```
typ.toString=="com.gu.marley.ExampleStruct" &&
 apply.toString=="method apply" &&
 termName.toString=="optListString"
```

...this breakpoint was hit for both Scala v2.13 & v2.12, so from there I could carefully step forward into the `implicitFor()` method, and see that the code diverged on this line:

https://github.com/guardian/marley/blob/849eae4d49895b169e53a9eb2ec7f565c544461c/core/src/main/scala/com/gu/marley/AvroSerialisable.scala#L287

...which - after carefully study of the types, and examining `seqType`, finally led to me understanding the issue.

### Another change for Scala <-> Java collection conversion

`scala.collection.convert.decorateAsJava` (introduced in Scala 2.8.1) is gone, switching to `scala.collection.JavaConverters` (also introduced in Scala 2.8.1?) although that _has_ been deprecated, apparently for `scala.jdk.CollectionConverters` in Scala 2.13.0 - we can switch over when we drop Scala 2.12 support.