### PR TITLE
Use current default branch name for Snyk workflow

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -6,7 +6,7 @@ name: Snyk
 on:
   push:
     branches:
-      - main
+      - master
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## What does this change?
Default branch name is not main, so this workflow never ran. Ideally the branch should be renamed, but this is a stopgap. 