### PR TITLE
Update To Latest Scala 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .idea/*
 target
-
+.bsp/

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
-scalaVersion in ThisBuild := "2.13.1"
+scalaVersion in ThisBuild := "2.13.10"
 
-crossScalaVersions in ThisBuild := Seq(scalaVersion.value, "2.12.10")
+crossScalaVersions in ThisBuild := Seq(scalaVersion.value, "2.12.17")
 
 val commonSettings = Seq(
   organization := "com.gu",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.8.2


### PR DESCRIPTION
## Why?

Good to update, and also a step on the path to Scala 3.

## Changes

- Update to sbt 1.8.2 because it will be needed for Scala 3
- Add `.bsp/` to `.gitignore` because later versions of sbt use this
