### PR TITLE
CI Uses Main Branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   # see https://docs.github.com/en/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
   push:
     branches:
-      - master
+      - main
 
 jobs:
   test:


### PR DESCRIPTION
## Why?

The repo was migrated to `main`.
