### PR TITLE
Update `scrooge-core` And `libthrift` To Latest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,8 +8,8 @@ val commonSettings = Seq(
   licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
   libraryDependencies ++= Seq(
     "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-    "com.twitter" %% "scrooge-core" % "19.10.0",
-    "org.apache.thrift" % "libthrift" % "0.12.0"
+    "com.twitter" %% "scrooge-core" % "22.12.0",
+    "org.apache.thrift" % "libthrift" % "0.17.0"
   )
 )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,14 +1,9 @@
 // Scrooge relies on an ancient version of thrift that's not on maven central
 // Instead, force a slightly more recent version
-libraryDependencies += "org.apache.thrift" % "libthrift" % "0.12.0"
+libraryDependencies += "org.apache.thrift" % "libthrift" % "0.17.0"
 
-addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "19.10.0")
+addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "22.12.0")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.12")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.12")
-
-
-
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
-


### PR DESCRIPTION
## Why?

Keeping libraries up to date.

Also dropped dependency graph plugin because it's built into recent versions of sbt.
