### PR TITLE
Bumped Deps To Versions That Support Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,10 +24,10 @@ lazy val core = project.settings(
   libraryDependencies ++= versionDependent(scalaBinaryVersion.value, handlesAnnotations=false,
     compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full)).toSeq ++ Seq(
     "org.apache.avro" % "avro" % "1.7.7",
-    "org.parboiled" %% "parboiled" % "2.1.8",
+    "org.parboiled" %% "parboiled" % "2.4.1",
     "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided",
-    "org.scalatest" %% "scalatest" % "3.0.9" % Test,
-    "org.scalacheck" %% "scalacheck" % "1.14.2" % Test
+    "org.scalatest" %% "scalatest" % "3.2.15" % Test,
+    "org.scalatestplus" %% "scalacheck-1-17" % "3.2.15.0" % Test
   ),
   Test/testOptions += Tests.Argument(
     TestFrameworks.ScalaTest,

--- a/core/src/test/scala/com/gu/marley/AvroFileSpec.scala
+++ b/core/src/test/scala/com/gu/marley/AvroFileSpec.scala
@@ -5,10 +5,10 @@ import java.io.File
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen._
 import org.scalacheck._
-import org.scalatest.FlatSpec
-import org.scalatest.prop.Checkers
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatestplus.scalacheck.Checkers
 
-class AvroFileSpec extends FlatSpec with Checkers {
+class AvroFileSpec extends AnyFlatSpec with Checkers {
   val union = ExampleUnion.Subunion1(SubUnion1("id"))
 
   it should "read back a file of page views it writes" in {

--- a/core/src/test/scala/com/gu/marley/enumsymbols/SnakesOnACamelTest.scala
+++ b/core/src/test/scala/com/gu/marley/enumsymbols/SnakesOnACamelTest.scala
@@ -1,8 +1,9 @@
 package com.gu.marley.enumsymbols
 
-import org.scalatest.{Matchers, FlatSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
-class SnakesOnACamelTest extends FlatSpec with Matchers {
+class SnakesOnACamelTest extends AnyFlatSpec with Matchers {
 
   it should "transform camel case with first-letter upper to snake case" in {
     SnakesOnACamel.toSnake("AndroidNative123App") should be ("ANDROID_NATIVE123_APP")


### PR DESCRIPTION
## Changes

- Updated scalacheck dep, because support is now in a separate artifact
- Updated tests to use new `AnyFlatSpec` class and other updated imports
