### PR TITLE
Bump `commons-compress` transitively to fix high vulnerability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,12 +16,13 @@ lazy val core = project.settings(
   name := "marley",
   Compile / scalacOptions ++= Seq("-release:11", "-Ymacro-annotations"),
   libraryDependencies ++= Seq(
-    "org.apache.avro" % "avro" % "1.11.3",
+    "org.apache.avro" % "avro" % "1.11.3" exclude("org.apache.commons", "commons-compress"),
     "org.xerial.snappy" % "snappy-java" % "1.1.10.5",
     "org.parboiled" %% "parboiled" % "2.5.0",
     "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided",
     "org.scalatest" %% "scalatest" % "3.2.16" % Test,
-    "org.scalatestplus" %% "scalacheck-1-17" % "3.2.16.0" % Test
+    "org.scalatestplus" %% "scalacheck-1-17" % "3.2.16.0" % Test,
+    "org.apache.commons" % "commons-compress" % "1.26.2"
   ),
   Test/testOptions += Tests.Argument(
     TestFrameworks.ScalaTest,

--- a/build.sbt
+++ b/build.sbt
@@ -16,13 +16,13 @@ lazy val core = project.settings(
   name := "marley",
   Compile / scalacOptions ++= Seq("-release:11", "-Ymacro-annotations"),
   libraryDependencies ++= Seq(
-    "org.apache.avro" % "avro" % "1.11.3" exclude("org.apache.commons", "commons-compress"),
+    "org.apache.avro" % "avro" % "1.11.3",
     "org.xerial.snappy" % "snappy-java" % "1.1.10.5",
     "org.parboiled" %% "parboiled" % "2.5.0",
     "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided",
     "org.scalatest" %% "scalatest" % "3.2.16" % Test,
     "org.scalatestplus" %% "scalacheck-1-17" % "3.2.16.0" % Test,
-    "org.apache.commons" % "commons-compress" % "1.26.0"
+    "org.apache.commons" % "commons-compress" % "1.26.2"
   ),
   Test/testOptions += Tests.Argument(
     TestFrameworks.ScalaTest,

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ lazy val core = project.settings(
     "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided",
     "org.scalatest" %% "scalatest" % "3.2.16" % Test,
     "org.scalatestplus" %% "scalacheck-1-17" % "3.2.16.0" % Test,
-    "org.apache.commons" % "commons-compress" % "1.26.2"
+    "org.apache.commons" % "commons-compress" % "1.26.0"
   ),
   Test/testOptions += Tests.Argument(
     TestFrameworks.ScalaTest,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## Why?

There is a high vulnerability introduced through version 1.24 of the `commons-compress` library. Info here: https://app.snyk.io/org/guardian-ophan/project/234d8861-20e1-4b9c-b41a-e7ed4f372d3e

Can fix by upgrading to 1.26.

The `commons-compress` dependency is introduced through `org.apache.avro`. The last release was in September 2023. This PR fixes it transitively while we wait for them to fix it on their side and release a patch.

## What does this change?

Upgrades `commons-compress` transitively to 1.26.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
