### PR TITLE
Keep test console output when junit output is used

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,13 +24,8 @@ lazy val core = project.settings(
     "org.scalatestplus" %% "scalacheck-1-17" % "3.2.16.0" % Test,
     "org.apache.commons" % "commons-compress" % "1.26.2"
   ),
-  Test / testOptions ++= Seq(
-    Tests.Argument(TestFrameworks.ScalaTest, "-o"),
-    Tests.Argument(
-      TestFrameworks.ScalaTest,
-      "-u", s"test-results/scala-${scalaVersion.value}"
-    )
-  )
+  Test / testOptions +=
+    Tests.Argument(TestFrameworks.ScalaTest, "-u", s"test-results/scala-${scalaVersion.value}", "-o")
 ).settings(commonSettings).dependsOn(thriftExample % "test->test")
 
 lazy val thriftExample = project.settings(commonSettings).settings(

--- a/build.sbt
+++ b/build.sbt
@@ -24,9 +24,12 @@ lazy val core = project.settings(
     "org.scalatestplus" %% "scalacheck-1-17" % "3.2.16.0" % Test,
     "org.apache.commons" % "commons-compress" % "1.26.2"
   ),
-  Test/testOptions += Tests.Argument(
-    TestFrameworks.ScalaTest,
-    "-u", s"test-results/scala-${scalaVersion.value}"
+  Test / testOptions ++= Seq(
+    Tests.Argument(TestFrameworks.ScalaTest, "-o"),
+    Tests.Argument(
+      TestFrameworks.ScalaTest,
+      "-u", s"test-results/scala-${scalaVersion.value}"
+    )
   )
 ).settings(commonSettings).dependsOn(thriftExample % "test->test")
 


### PR DESCRIPTION
Before now, scalatest’s output was never sent to standard out: the default behaviour when passing the “-u” flag is to omit it. This is a bit irritating when running locally, because it makes it hard to tell which tests have failed.

This commit changes the behaviour to always send scalatest’s output to standard out, as well as writing to junit files.

This lets us keep the benefits of the XML output in CI (annotations pointing to the source files), while making the tests more useful when run locally.

This PR is a copy of the changes @fredex42 and I made to crier in https://github.com/guardian/crier/pull/174 (specifically commit https://github.com/guardian/crier/commit/59206fae5b65b5ece9b83df65f1b3bcba1637155)