### PR TITLE
Upgrade libthrift for CVE-2026-43869

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ val commonSettings = Seq(
   libraryDependencies ++= Seq(
     "org.scala-lang" % "scala-reflect" % scalaVersion.value,
     "com.twitter" %% "scrooge-core" % "22.12.0",
-    "org.apache.thrift" % "libthrift" % "0.17.0"
+    "org.apache.thrift" % "libthrift" % "0.23.0"
   )
 )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,5 @@
-// Scrooge relies on an ancient version of thrift that's not on maven central
-// Instead, force a slightly more recent version
-libraryDependencies += "org.apache.thrift" % "libthrift" % "0.17.0"
+// Scrooge relies on libthrift at build time for thrift generation.
+libraryDependencies += "org.apache.thrift" % "libthrift" % "0.23.0"
 
 addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "22.12.0")
 


### PR DESCRIPTION
## What changed

Upgrades Apache Thrift to the patched `0.23.0` release for both runtime dependencies and the Scrooge build-time dependency.

## Vulnerability resolved

- GHSA-7pwc-h2j2-rjgj / CVE-2026-43869 (`org.apache.thrift:libthrift`)

## Validation/testing

Added the Ophan-side validation for this Marley/libthrift upgrade.

What I tested locally:

1. Published this Marley branch locally as `com.gu:marley_2.13:0.5.1-SNAPSHOT` after `sbt test publishLocal` passed in Marley.
2. Temporarily pointed Ophan `avroLogger` at that local Marley snapshot.
3. The Slab published user records for avro-logger to consume.
4. Avro Logger wrote Avro batches successfully, including `40 written`, `1308 written`, and `4299 written` batches.
5. Avro Logger health check returned `200 OK`: `OK - 30722 processed` / `KinesisRunner$ [RUNNING]`.

This exercises the Marley runtime path used by Ophan Avro Logger, which is the part of Ophan that depends on Marley. The Slab/Big Loader path does not use Marley directly, so I used The Slab only to produce real events into the DEV stream for Avro Logger to consume.

GHA for this PR is green: https://github.com/guardian/marley/actions/runs/25725586807/job/75537386976

Vulnerability being resolved: `org.apache.thrift:libthrift` / GHSA-7pwc-h2j2-rjgj.

## GitHub Actions

- Branch CI: https://github.com/guardian/marley/actions?query=branch%3Acodex%2Flibthrift-ghsa-7pwc-h2j2-rjgj
